### PR TITLE
Altera 'user' para 'resident' nas queries

### DIFF
--- a/bot/auth.py
+++ b/bot/auth.py
@@ -107,7 +107,7 @@ def voice_auth(update, context):
 
     response = authenticate(chat_id)
 
-    valid = response['data']['voiceBelongsUser']
+    valid = response['data']['voiceBelongsResident']
 
     if valid:
         update.message.reply_text('Autenticado(a) com sucesso!')
@@ -128,11 +128,11 @@ def end_auth(update, context):
 
 def authenticate(chat_id):
     query = """
-    query voiceBelongsUser(
+    query voiceBelongsResident(
         $cpf: String!,
         $mfccData: String
     ){
-        voiceBelongsUser(cpf: $cpf, mfccData: $mfccData)
+        voiceBelongsResident(cpf: $cpf, mfccData: $mfccData)
     }
     """
 

--- a/bot/register.py
+++ b/bot/register.py
@@ -283,7 +283,7 @@ def end(update, context):
 
 def register_user(chat_id):
     query = """
-    mutation createUser(
+    mutation createResident(
         $completeName: String!,
         $email: String!,
         $phone: String!,
@@ -293,7 +293,7 @@ def register_user(chat_id):
         $voiceData: String,
         $mfccData: String,
         ){
-        createUser(
+        createResident(
             completeName: $completeName,
             email: $email,
             cpf: $cpf,
@@ -303,7 +303,7 @@ def register_user(chat_id):
             voiceData: $voiceData
             mfccData: $mfccData
         ){
-            user{
+            resident{
                 completeName
                 email
                 cpf


### PR DESCRIPTION
## Descrição

Altera 'user' para 'resident' nas queries de cadastro e autenticação para adaptar às modificações feitas nas models

## Tipo de mudança

- [X] Bugfix
- [ ] Funcionalidade nova
- [ ] Mudança de funcionalidade

## Comentários adicionais
É complemento da branch que resolve a issue 102 do repositório da API
