### PR TITLE
24 adicionar grupos de comandos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Em: https://github.com/fga-eps-mds/2019.2-Alohomora/releases
 *  Interação de visitante para solicitar uma entrada.
 *  Interação do morador para lidar com a entrada do visitante.
 
+## [0.1.0] - 2019-11-12
+### Adicionado
+* Interação para visitantes e moradores terem seus comando listados.
+
  ---
  Modelo padrão do changelog disponível [aqui](https://keepachangelog.com/en/0.3.0/).
 

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,0 +1,20 @@
+import logging
+
+logger = logging.getLogger(LOG_NAME)
+
+chat = {}
+
+class Commands:
+    def morador(update, context):
+        logger.info()
+        update.message.reply_text("Como morador você pode:")
+        update.message.reply_text("Autorizar a entrada de um visitante: /autorizar")
+        update.message.reply_text("Cadastrar-se no sistema: /cadastrar")
+        update.message.reply_text("Dar um feedback ao serviço: /feedback")
+        
+
+    def visitante(update, context):
+        logger.info()
+        update.message.reply_text("Como visitante você pode:")
+        update.message.reply_text("Realizar o pedido de uma visita: /visitar")
+        update.message.reply_text("Dar um feedback ao serviço: /feedback")

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,3 +1,4 @@
+from settings import LOG_NAME
 import logging
 
 logger = logging.getLogger(LOG_NAME)
@@ -6,7 +7,7 @@ chat = {}
 
 class Commands:
     def morador(update, context):
-        logger.info()
+        logger.info("Listing resident commands")
         update.message.reply_text("Como morador você pode:")
         update.message.reply_text("Autorizar a entrada de um visitante: /autorizar")
         update.message.reply_text("Cadastrar-se no sistema: /cadastrar")
@@ -14,7 +15,7 @@ class Commands:
         
 
     def visitante(update, context):
-        logger.info()
+        logger.info("Listing visitor commands")
         update.message.reply_text("Como visitante você pode:")
         update.message.reply_text("Realizar o pedido de uma visita: /visitar")
         update.message.reply_text("Dar um feedback ao serviço: /feedback")

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -1,19 +1,25 @@
-from settings import LOG_NAME
+"""
+Provides commands for the bot users
+"""
 import logging
+from settings import LOG_NAME
 
 logger = logging.getLogger(LOG_NAME)
 
 chat = {}
 
 class Commands:
+    """Provides commands for the bot users"""
     def resident(update, context):
+        """Command to display resident's iterations"""
         logger.info("Listing resident commands")
         update.message.reply_text("Como morador você pode:")
         update.message.reply_text("Autorizar a entrada de um visitante: /autorizar")
         update.message.reply_text("Cadastrar-se no sistema: /cadastrar")
-        
+
 
     def visitor(update, context):
+        """Command to display visitor's iterations"""
         logger.info("Listing visitor commands")
         update.message.reply_text("Como visitante você pode:")
         update.message.reply_text("Realizar o pedido de uma visita: /visitar")

--- a/bot/commands.py
+++ b/bot/commands.py
@@ -6,16 +6,14 @@ logger = logging.getLogger(LOG_NAME)
 chat = {}
 
 class Commands:
-    def morador(update, context):
+    def resident(update, context):
         logger.info("Listing resident commands")
         update.message.reply_text("Como morador você pode:")
         update.message.reply_text("Autorizar a entrada de um visitante: /autorizar")
         update.message.reply_text("Cadastrar-se no sistema: /cadastrar")
-        update.message.reply_text("Dar um feedback ao serviço: /feedback")
         
 
-    def visitante(update, context):
+    def visitor(update, context):
         logger.info("Listing visitor commands")
         update.message.reply_text("Como visitante você pode:")
         update.message.reply_text("Realizar o pedido de uma visita: /visitar")
-        update.message.reply_text("Dar um feedback ao serviço: /feedback")

--- a/bot/main.py
+++ b/bot/main.py
@@ -43,10 +43,10 @@ def start(update, context):
         'Olá, bem vindo(a) ao bot do Alohomora!'
     )
     update.message.reply_text(
-        'Caso você seja um morador, digite /morador para listar os comandos ligados aos moradores'
+        'Digite /morador para listar os comandos ligados aos moradores'
     )
     update.message.reply_text(
-        'Caso você seja um visitante, digite /visitante para listar os comandos ligados aos visitantes'
+        'Digite /visitante para listar os comandos ligados aos visitantes'
     )
     update.message.reply_text(
         'Para dar um feedback pro nosso serviço, digite /feedback'
@@ -131,7 +131,7 @@ if __name__ == '__main__':
 
         fallbacks=[CommandHandler('cancelar', Feedback.end)]
         ))
-    
+
     # Listing resident commands
     dp.add_handler(CommandHandler('morador', Commands.resident))
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -28,11 +28,8 @@ logger.addHandler(file_handler)
 def start(update, context):
     logger.info("Introducing the bot")
     update.message.reply_text('Olá, bem vindo(a) ao bot do Alohomora!')
-    update.message.reply_text('Caso deseje fazer uma solicitação de visita a algum morador, digite /visitar')
-    update.message.reply_text('Digite /cadastrar para fazer o cadastro de um morador')
-    update.message.reply_text('Digite /autorizar para autorizar entrada de algum visitante')
-    update.message.reply_text('Para listar os comandos ligados aos moradores, digite /morador')
-    update.message.reply_text('Para listar os comandos ligados aos visitantes, digite /visitante')
+    update.message.reply_text('Caso você seja um morador, digite /morador para listar os comandos ligados aos moradores')
+    update.message.reply_text('Caso você seja um visitante, digite /visitante para listar os comandos ligados aos visitantes')
     update.message.reply_text('Para dar um feedback pro nosso serviço, digite /feedback')
 
 
@@ -107,9 +104,9 @@ if __name__ == '__main__':
         fallbacks=[CommandHandler('cancelar', Feedback.end)]
         ))
     
-    dp.add_handler(CommandHandler('morador', Commands.morador))
+    dp.add_handler(CommandHandler('morador', Commands.resident))
 
-    dp.add_handler(CommandHandler('visitante', Commands.visitante))
+    dp.add_handler(CommandHandler('visitante', Commands.visitor))
 
     updater.start_polling()
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,3 +1,4 @@
+from commands import *
 from resident_control import Auth, HandleEntryVisitor
 from register import Register
 from register_visitor import RegisterVisitor
@@ -30,6 +31,8 @@ def start(update, context):
     update.message.reply_text('Caso deseje fazer uma solicitação de visita a algum morador, digite /visitar')
     update.message.reply_text('Digite /cadastrar para fazer o cadastro de um morador')
     update.message.reply_text('Digite /autorizar para autorizar entrada de algum visitante')
+    update.message.reply_text('Para listar os comandos ligados aos moradores, digite /morador')
+    update.message.reply_text('Para listar os comandos ligados aos visitantes, digite /visitante')
     update.message.reply_text('Para dar um feedback pro nosso serviço, digite /feedback')
 
 
@@ -103,7 +106,10 @@ if __name__ == '__main__':
 
         fallbacks=[CommandHandler('cancelar', Feedback.end)]
         ))
+    
+    dp.add_handler(CommandHandler('morador', Commands.morador))
 
+    dp.add_handler(CommandHandler('visitante', Commands.visitante))
 
     updater.start_polling()
 


### PR DESCRIPTION
## Issue
    
Resolve #24 
## Descrição
Foram criadas duas novas interações /morador e /visitante que listam os comandos do que cada um tem acesso.

Ps.: não há listagem quanto aos comandos de Administradores pois ainda não há interações com o bot que sejam para eles.

## Tipo de mudança

- [ ] Bugfix
- [X] Funcionalidade nova
- [ ] Mudança de funcionalidade

## Comentários adicionais

Informações complementares
